### PR TITLE
Allows double-slash comments

### DIFF
--- a/grammars/arm.cson
+++ b/grammars/arm.cson
@@ -9,7 +9,7 @@
 ]
 'patterns': [
   {
-    'match': '([;@]|//)(.*$|.*:$)'
+    'match': '([;@]|//).*$'
     'name': 'comment.arm'
   }
   {
@@ -24,10 +24,9 @@
     'end': '\\*\\/'
   }
   {
-    'match': '.*:$'
+    'match': '^\\s*\\.?\\w+:\\s*(?=$|;)'
     'name': 'routine.arm'
   }
-
   {
     'name': 'string.quoted.arm'
     'begin': '"'

--- a/grammars/arm.cson
+++ b/grammars/arm.cson
@@ -9,7 +9,7 @@
 ]
 'patterns': [
   {
-    'match': '[;@].*$'
+    'match': '([;@]|//)(.*$|.*:$)'
     'name': 'comment.arm'
   }
   {


### PR DESCRIPTION
Allows double-slash comments and also properly applies syntax to comments ending in a colon.
Previously, comments including a colon at the end of a line were classified as an `arm.routine`.
Fixes #2